### PR TITLE
Added hashbang to executables

### DIFF
--- a/decensor.py
+++ b/decensor.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 try:
     import numpy as np
     from PIL import Image

--- a/ui.py
+++ b/ui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Code illustration: 6.09
     


### PR DESCRIPTION
This PR just adds hashbangs to executable files so instead of typing under Linux (or Windows 10 Bash):
```
python3 ui.py
```
You can just double click on it, or type:
```
./ui.py
```

This is still compatible with Virtualenv and OSes other than Linux.