### PR TITLE
Faster region finding, region grouping

### DIFF
--- a/decensor.py
+++ b/decensor.py
@@ -16,13 +16,14 @@ except ImportError as err:
     print("Could not import modules. Make sure all dependencies are installed.")
     exit(1)
 
+
 class Decensor:
 
     def __init__(self):
         self.args = config.get_args()
         self.is_mosaic = self.args.is_mosaic
 
-        self.mask_color = [float(v/255) for v in self.args.mask_color] # normalize mask color
+        self.mask_color = [float(v/255) for v in self.args.mask_color]  # normalize mask color
 
         if not os.path.exists(self.args.decensor_output_path):
             os.makedirs(self.args.decensor_output_path)
@@ -44,37 +45,37 @@ class Decensor:
         )
 
     def decensor_all_images_in_folder(self):
-        #load model once at beginning and reuse same model
-        #self.load_model()
+        # load model once at beginning and reuse same model
+        # self.load_model()
         color_dir = self.args.decensor_input_path
         file_names = os.listdir(color_dir)
-        
+
         input_dir = self.args.decensor_input_path
         output_dir = self.args.decensor_output_path
-        
-        # Change False to True before release --> file.check_file( input_dir, output_dir, True)
-        file_names, self.files_removed = file.check_file( input_dir, output_dir, False)
 
-        #convert all images into np arrays and put them in a list
+        # Change False to True before release --> file.check_file( input_dir, output_dir, True)
+        file_names, self.files_removed = file.check_file(input_dir, output_dir, False)
+
+        # convert all images into np arrays and put them in a list
         for file_name in file_names:
             color_file_path = os.path.join(color_dir, file_name)
             color_bn, color_ext = os.path.splitext(file_name)
             if os.path.isfile(color_file_path) and color_ext.casefold() == ".png":
                 print("--------------------------------------------------------------------------")
                 print("Decensoring the image {}".format(color_file_path))
-                try :
+                try:
                     colored_img = Image.open(color_file_path)
                 except:
-                    print("Cannot identify image file (" +str(color_file_path)+")")
-                    self.files_removed.append((color_file_path,3))
+                    print("Cannot identify image file (" + str(color_file_path)+")")
+                    self.files_removed.append((color_file_path, 3))
                     # incase of abnormal file format change (ex : text.txt -> text.png)
                     continue
-                    
-                #if we are doing a mosaic decensor
+
+                # if we are doing a mosaic decensor
                 if self.is_mosaic:
-                    #get the original file that hasn't been colored
+                    # get the original file that hasn't been colored
                     ori_dir = self.args.decensor_input_original_path
-                    #since the original image might not be a png, test multiple file formats
+                    # since the original image might not be a png, test multiple file formats
                     valid_formats = {".png", ".jpg", ".jpeg"}
                     for test_file_name in os.listdir(ori_dir):
                         test_bn, test_ext = os.path.splitext(test_file_name)
@@ -84,7 +85,7 @@ class Decensor:
                             # colored_img.show()
                             self.decensor_image(ori_img, colored_img, file_name)
                             break
-                    else: #for...else, i.e if the loop finished without encountering break
+                    else:  # for...else, i.e if the loop finished without encountering break
                         print("Corresponding original, uncolored image not found in {}".format(color_file_path))
                         print("Check if it exists and is in the PNG or JPG format.")
                 else:
@@ -96,29 +97,29 @@ class Decensor:
         if(self.files_removed is not None):
             file.error_messages(None, self.files_removed)
         input("\nPress anything to end...")
-        
-    #decensors one image at a time
-    #TODO: decensor all cropped parts of the same image in a batch (then i need input for colored an array of those images and make additional changes)
+
+    # decensors one image at a time
+    # TODO: decensor all cropped parts of the same image in a batch (then i need input for colored an array of those images and make additional changes)
     def decensor_image(self, ori, colored, file_name=None):
         width, height = ori.size
-        #save the alpha channel if the image has an alpha channel
+        # save the alpha channel if the image has an alpha channel
         has_alpha = False
         if (ori.mode == "RGBA"):
             has_alpha = True
-            alpha_channel = np.asarray(ori)[:,:,3]
-            alpha_channel = np.expand_dims(alpha_channel, axis =-1)
+            alpha_channel = np.asarray(ori)[:, :, 3]
+            alpha_channel = np.expand_dims(alpha_channel, axis=-1)
             ori = ori.convert('RGB')
 
         ori_array = image_to_array(ori)
-        ori_array = np.expand_dims(ori_array, axis = 0)
+        ori_array = np.expand_dims(ori_array, axis=0)
 
         if self.is_mosaic:
-            #if mosaic decensor, mask is empty
+            # if mosaic decensor, mask is empty
             # mask = np.ones(ori_array.shape, np.uint8)
             # print(mask.shape)
             colored = colored.convert('RGB')
             color_array = image_to_array(colored)
-            color_array = np.expand_dims(color_array, axis = 0)
+            color_array = np.expand_dims(color_array, axis=0)
             mask = self.get_mask(color_array)
             # mask_reshaped = mask[0,:,:,:] * 255.0
             # mask_img = Image.fromarray(mask_reshaped.astype('uint8'))
@@ -127,20 +128,50 @@ class Decensor:
         else:
             mask = self.get_mask(ori_array)
 
-        #colored image is only used for finding the regions
-        regions = find_regions(colored.convert('RGB'), [v*255 for v in self.mask_color]) #unnormalize the color so it can check against pixels
-        print("Found {region_count} censored regions in this image!".format(region_count = len(regions)))
+        # colored image is only used for finding the regions
+        # regions = find_regions(colored.convert('RGB'), [v*255 for v in self.mask_color]) #unnormalize the color so it can check against pixels
+        regions = region_by_mask(mask)
+        print("Found {region_count} censored regions in this image!".format(region_count=len(regions)))
 
         if len(regions) == 0 and not self.is_mosaic:
             print("No green regions detected! Make sure you're using exactly the right color.")
             return
 
         output_img_array = ori_array[0].copy()
+        box_bounds = []
+        for region in regions:
+            bounding_box = expand_bounding_mk2(ori, region, expand_factor=1.25, min_size=64)
 
-        for region_counter, region in enumerate(regions, 1):
-            bounding_box = expand_bounding(ori, region)
+            if (len(box_bounds) == 0):
+                boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+                if (boxCheck[0]):
+                    box_bounds.append([boxCheck[1], [bounding_box], [region]])
+                    continue
+                else:
+                    print("Could not create bounding box for censored area. Aborting.")
+                    return
+            for i in range(len(box_bounds)):
+                boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
+                if (boxCheck[0]):
+                    box_bounds[i][0] = boxCheck[1]
+                    box_bounds[i][1].append(bounding_box)
+                    box_bounds[i][2].append(region)
+                    break
+                else:
+                    if (i == len(box_bounds) - 1):
+                        boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+                        if (boxCheck[0]):
+                            box_bounds.append([boxCheck[1], [bounding_box], [region]])
+                        else:
+                            print("Could not create bounding box for censored area. Aborting.")
+                            return
+
+        print("Converted {region_count} censored regions into {box_count} regions!".format(region_count=len(regions), box_count=len(box_bounds)))
+
+        for region_counter, box_object in enumerate(box_bounds, 1):
+            bounding_box = box_object[0]
+            cens_regions = box_object[2]
             crop_img = ori.crop(bounding_box)
-            # crop_img.show()
             #convert mask back to image
             mask_reshaped = mask[0,:,:,:] * 255.0
             mask_img = Image.fromarray(mask_reshaped.astype('uint8'))
@@ -151,49 +182,48 @@ class Decensor:
             #resize the mask images
             mask_img = mask_img.crop(bounding_box)
             mask_img = mask_img.resize((512, 512))
-            # mask_img.show()
             #convert mask_img back to array 
             mask_array = image_to_array(mask_img)
-            #the mask has been upscaled so there will be values not equal to 0 or 1
 
+            #the mask has been upscaled so there will be values not equal to 0 or 
             mask_array[mask_array > 0] = 1
-            
-            if self.is_mosaic:
-                a, b = np.where(np.all(mask_array == 0, axis = -1))
-                print(a, b)
-                coords = [coord for coord in zip(a,b) if ((coord[0] + coord[1]) % 2 == 0)]
-                a,b = zip(*coords)
 
-                mask_array[a,b] = 1
+            if self.is_mosaic:
+                a, b = np.where(np.all(mask_array == 0, axis=-1))
+                print(a, b)
+                coords = [coord for coord in zip(a, b) if ((coord[0] + coord[1]) % 2 == 0)]
+                a, b = zip(*coords)
+
+                mask_array[a, b] = 1
                 # mask_array = mask_array * 255.0
                 # img = Image.fromarray(mask_array.astype('uint8'))
                 # img.show()
                 # return
 
-            mask_array = np.expand_dims(mask_array, axis = 0)
+            mask_array = np.expand_dims(mask_array, axis=0)
 
             # Run predictions for this batch of images
             pred_img_array = self.model.predict([crop_img_array, mask_array, mask_array])
-            
+
             pred_img_array = pred_img_array * 255.0
             pred_img_array = np.squeeze(pred_img_array, axis = 0)
-
+      
             #scale prediction image back to original size
             bounding_width = bounding_box[2]-bounding_box[0]
             bounding_height = bounding_box[3]-bounding_box[1]
-            #convert np array to image
+            # convert np array to image
 
             # print(bounding_width,bounding_height)
             # print(pred_img_array.shape)
 
             pred_img = Image.fromarray(pred_img_array.astype('uint8'))
             # pred_img.show()
-            pred_img = pred_img.resize((bounding_width, bounding_height), resample = Image.BICUBIC)
+            pred_img = pred_img.resize((bounding_width, bounding_height), resample=Image.BICUBIC)
 
             pred_img_array = image_to_array(pred_img)
 
             # print(pred_img_array.shape)
-            pred_img_array = np.expand_dims(pred_img_array, axis = 0)
+            pred_img_array = np.expand_dims(pred_img_array, axis=0)
 
             # copy the decensored regions into the output image
             for i in range(len(ori_array)):
@@ -201,20 +231,21 @@ class Decensor:
                     for row in range(bounding_height):
                         bounding_width_index = col + bounding_box[0]
                         bounding_height_index = row + bounding_box[1]
-                        if (bounding_width_index, bounding_height_index) in region:
-                            output_img_array[bounding_height_index][bounding_width_index] = pred_img_array[i,:,:,:][row][col]
-            print("{region_counter} out of {region_count} regions decensored.".format(region_counter=region_counter, region_count=len(regions)))
+                        for region in cens_regions:
+                            if (bounding_width_index, bounding_height_index) in region:
+                                output_img_array[bounding_height_index][bounding_width_index] = pred_img_array[i, :, :, :][row][col]
+            print("{region_counter} out of {region_count} regions decensored.".format(region_counter=region_counter, region_count=len(box_bounds)))
 
         output_img_array = output_img_array * 255.0
 
-        #restore the alpha channel if the image had one
+        # restore the alpha channel if the image had one
         if has_alpha:
-            output_img_array = np.concatenate((output_img_array, alpha_channel), axis = 2)
+            output_img_array = np.concatenate((output_img_array, alpha_channel), axis=2)
 
         output_img = Image.fromarray(output_img_array.astype('uint8'))
 
         if file_name != None:
-            #save the decensored image
+            # save the decensored image
             #file_name, _ = os.path.splitext(file_name)
             save_path = os.path.join(self.args.decensor_output_path, file_name)
             output_img.save(save_path)
@@ -224,6 +255,7 @@ class Decensor:
         else:
             print("Decensored image. Returning it.")
             return output_img
+
 
 if __name__ == '__main__':
     decensor = Decensor()

--- a/decensor.py
+++ b/decensor.py
@@ -130,6 +130,8 @@ class Decensor:
 
         # colored image is only used for finding the regions
         # regions = find_regions(colored.convert('RGB'), [v*255 for v in self.mask_color]) #unnormalize the color so it can check against pixels
+        
+        # Find regions by mask instead of by color
         regions = region_by_mask(mask)
         print("Found {region_count} censored regions in this image!".format(region_count=len(regions)))
 
@@ -138,44 +140,56 @@ class Decensor:
             return
 
         output_img_array = ori_array[0].copy()
+        # Initialize array to store all the groups
         box_bounds = []
+        # Iterate over all found regions to group them into bigger boxes for faster processing
         for region in regions:
+            # Expand and get the bounding of the current region 
             bounding_box = expand_bounding_mk2(ori, region, expand_factor=1.25, min_size=64)
 
+            # If this is the first region being processed, create a big bounding box around it
             if (len(box_bounds) == 0):
-                boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+                boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
+                # Check that the box has the correct size / if the censor region is too big
                 if (boxCheck[0]):
                     box_bounds.append([boxCheck[1], [bounding_box], [region]])
-                    continue
                 else:
-                    print("Could not create bounding box for censored area. Aborting.")
-                    return
+                    print("Censor region exceeds boundary: {}".format(bounding_box))
+                continue   
+            # Iterate over all big boxes (group boxes) 
             for i in range(len(box_bounds)):
+                # Check if the current region fits into a box
                 boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
+                # If it fits, append to this box and update box coordinates
                 if (boxCheck[0]):
                     box_bounds[i][0] = boxCheck[1]
                     box_bounds[i][1].append(bounding_box)
                     box_bounds[i][2].append(region)
                     break
                 else:
+                    # If we don't have more boxes to check then we can try to create a new box
                     if (i == len(box_bounds) - 1):
-                        boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+                        # If the region didn't fit, create a new big box (or do nothing if area is too big)
+                        boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
                         if (boxCheck[0]):
                             box_bounds.append([boxCheck[1], [bounding_box], [region]])
                         else:
-                            print("Could not create bounding box for censored area. Aborting.")
-                            return
+                            print("Censor region exceeds boundary: {}".format(bounding_box))
 
         print("Converted {region_count} censored regions into {box_count} regions!".format(region_count=len(regions), box_count=len(box_bounds)))
 
+        # Iterate over every grouping box
         for region_counter, box_object in enumerate(box_bounds, 1):
+            # Access the bounding box
             bounding_box = box_object[0]
+            # Access the censored regions
             cens_regions = box_object[2]
+
             crop_img = ori.crop(bounding_box)
             #convert mask back to image
             mask_reshaped = mask[0,:,:,:] * 255.0
             mask_img = Image.fromarray(mask_reshaped.astype('uint8'))
-            #resize the cropped images
+            #resize the cropped images, this will not matter if grouped because the boxes are already 512,512
             crop_img = crop_img.resize((512, 512))
             crop_img_array = image_to_array(crop_img)
             crop_img_array = np.expand_dims(crop_img_array, axis = 0)
@@ -211,11 +225,11 @@ class Decensor:
             #scale prediction image back to original size
             bounding_width = bounding_box[2]-bounding_box[0]
             bounding_height = bounding_box[3]-bounding_box[1]
-            # convert np array to image
 
             # print(bounding_width,bounding_height)
             # print(pred_img_array.shape)
 
+            # convert np array to image
             pred_img = Image.fromarray(pred_img_array.astype('uint8'))
             # pred_img.show()
             pred_img = pred_img.resize((bounding_width, bounding_height), resample=Image.BICUBIC)
@@ -231,6 +245,7 @@ class Decensor:
                     for row in range(bounding_height):
                         bounding_width_index = col + bounding_box[0]
                         bounding_height_index = row + bounding_box[1]
+                        # Iterate over every region in this bounding box
                         for region in cens_regions:
                             if (bounding_width_index, bounding_height_index) in region:
                                 output_img_array[bounding_height_index][bounding_width_index] = pred_img_array[i, :, :, :][row][col]

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -18,7 +18,7 @@ def image_to_array(image):
 
 # Find all the regions of the masked picture
 # All marked regions should have the value 0, all else should be 1
-def region_by_mask(mask):
+def find_regions(mask):
     # Gets all of the coordinates where the mask exists
     i, j = np.where(np.all(mask[0], axis=-1) == 0)
     if len(i) == 0:
@@ -55,63 +55,54 @@ def region_by_mask(mask):
     regions.sort(key=len, reverse=True)
     return regions
 
-# Expand the box surrounding the region area.
-def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=512):
-    # expand bounding box to capture more context
-    if not isinstance(region, set) and len(region) == 4:
-        min_x, min_y, max_x, max_y = region[0], region[1], region[2], region[3]
-    else:
-        x, y = zip(*region)
-        min_x, min_y, max_x, max_y = min(x), min(y), max(x), max(y)
-
+# risk of box being bigger than the image
+def expand_bounding(img, region, expand_factor=1.5, min_size = 256):
+    #expand bounding box to capture more context
+    x, y = zip(*region)
+    min_x, min_y, max_x, max_y = min(x), min(y), max(x), max(y)
     width, height = img.size
+    width_center = width//2
+    height_center = height//2
     bb_width = max_x - min_x
     bb_height = max_y - min_y
     x_center = (min_x + max_x)//2
     y_center = (min_y + max_y)//2
     current_size = max(bb_width, bb_height)
-    current_size = int(current_size * expand_factor)
-    bb_width = int(bb_width * expand_factor)
-    bb_height = int(bb_height * expand_factor)
-    if bb_width > max_size:
-        bb_width = max_size
-    if bb_width < min_size:
-        bb_width = min_size
-
-    if bb_height > max_size:
-        bb_height = max_size
-    if bb_height < min_size:
-        bb_height = min_size
-
-    x1 = x_center - bb_width//2
-    x2 = x_center + bb_width//2
-    y1 = y_center - bb_height//2
-    y2 = y_center + bb_height//2
+    current_size  = int(current_size * expand_factor)
+    max_size = min(width, height)
+    if current_size > max_size:
+        current_size = max_size
+    elif current_size < min_size:
+        current_size = min_size
+    x1 = x_center - current_size//2
+    x2 = x_center + current_size//2
+    y1 = y_center - current_size//2
+    y2 = y_center + current_size//2
     x1_square = x1
     y1_square = y1
     x2_square = x2
     y2_square = y2
-
+    #move bounding boxes that are partially outside of the image inside the image
     if (y1_square < 0 or y2_square > (height - 1)) and (x1_square < 0 or x2_square > (width - 1)):
-        # conservative square region
+        #conservative square region
         if x1_square < 0 and y1_square < 0:
             x1_square = 0
             y1_square = 0
-            x2_square = bb_width
-            y2_square = bb_height
+            x2_square = current_size
+            y2_square = current_size
         elif x2_square > (width - 1) and y1_square < 0:
-            x1_square = width - bb_width - 1
+            x1_square = width - current_size - 1
             y1_square = 0
             x2_square = width - 1
-            y2_square = bb_height
+            y2_square = current_size
         elif x1_square < 0 and y2_square > (height - 1):
             x1_square = 0
-            y1_square = height - bb_height - 1
-            x2_square = bb_width
+            y1_square = height - current_size - 1
+            x2_square = current_size
             y2_square = height - 1
         elif x2_square > (width - 1) and y2_square > (height - 1):
-            x1_square = width - bb_width - 1
-            y1_square = height - bb_height - 1
+            x1_square = width - current_size - 1
+            y1_square = height - current_size - 1
             x2_square = width - 1
             y2_square = height - 1
         else:
@@ -136,227 +127,39 @@ def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=
             difference = y2_square - height + 1
             y1_square -= difference
             y2_square -= difference
+    # if y1_square < 0 or y2_square > (height - 1):
 
-    # If the box is out of bounds, return to the original coordinates
+    #if bounding box goes outside of the image for some reason, set bounds to original, unexpanded values
+    #print(width, height)
     if x2_square > width or y2_square > height:
         print("bounding box out of bounds!")
         print(x1_square, y1_square, x2_square, y2_square)
         x1_square, y1_square, x2_square, y2_square = min_x, min_y, max_x, max_y
-    return int(x1_square), int(y1_square), int(x2_square), int(y2_square)
+    return x1_square, y1_square, x2_square, y2_square
 
-# Creates a new big box around the specified box. 
-# Size is the size of the picture, and not the box, which is meant to limit the coordinates of the box
-# as to not go outside of the picture.
-# Index 0 of the return array is a boolean mentioning if the box is too big to fit in the picture (False if too big).
-def bounding_box_check_mk2(size, box, target_size=(512, 512)):
-    inside = True
-    # Get the boundaries of the box
-    minX = min(box[0], box[2])
-    maxX = max(box[0], box[2])
-    minY = min(box[1], box[3])
-    maxY = max(box[1], box[3])
-
-    # If the box has a width less than or equal to the target size (512, 512)
-    # a bigger box is created, centered around it
-    b_width = maxX - minX
-    if b_width <= target_size[0]:
-        dist_left = target_size[0] - b_width
-        if dist_left != 0:
-            minX = round(minX - dist_left/2)
-            maxX = round(maxX + dist_left/2)
-    else:
-        print('Censor region is too big')
-        inside = False
-
-    b_height = maxY - minY
-    if b_height <= target_size[1]:
-        dist_left = target_size[1] - b_height
-        if dist_left != 0:
-            minY = round(minY - dist_left/2)
-            maxY = round(maxY + dist_left/2)
-    else:
-        print('Censor region is too big')
-        inside = False
-
-    # This shifts the box so that it does not go outside of the picture
-    minX, minY = shift(size, minX, minY)
-
-    # Shrink/move the box horizontally if it is bigger than the picture
-    if (minX < 0 or minX + target_size[0] > size[0]):
-        print("No possible box of size 512,512 possible")
-        maxX = size[0]
-    else:
-        maxX = minX + target_size[0]
-
-    minX = max(0, minX)
-
-    # Shrink/move the box vertically if it is bigger than the picture
-    if (minY < 0 or minY + target_size[1] > size[1]):
-        maxY = size[1]
-    else:
-        maxY = minY + target_size[1]
-
-    minY = max(0, minY)
-
-    return [inside, (minX, minY, maxX, maxY)]
-
-# Check if box1 fits into big_box by checking if it is within range of all other boxes.
-# Size is the size of the picture and not the size of the box.
-def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
-    inside = True
-
-    # Initialize maxX,maxY,minX,minY
-    maxX = max(box1[0], box1[2])
-    maxY = max(box1[1], box1[3])
-
-    minX = min(box1[0], box1[2])
-    minY = min(box1[1], box1[3])
-
-    # Check all the boxes for the correct min/max values
-    for box in boxes:
-        maxX = max(maxX, box[0], box[2])
-        maxY = max(maxY, box[1], box[3])
-
-        minX = min(minX, box[0], box[2])
-        minY = min(minY, box[1], box[3])
-
-    # Get the total width of the new big box
-    b_width = maxX - minX
-
-    # If the new big box has a width less than or equal to the target size (512, 512)
-    # the new box fits into the group, and the big box can be moved accordingly
-    if b_width <= target_size[0]:
-        dist_left = target_size[0] - b_width
-        if dist_left != 0:
-            minX = round(minX - dist_left/2)
-            maxX = round(maxX + dist_left/2)
-    else:
-        inside = False
-
-    # Same deal for the height as for the width above
-    b_height = maxY - minY
-    if b_height <= target_size[1]:
-        dist_left = target_size[1] - b_height
-        if dist_left != 0:
-            minY = round(minY - dist_left/2)
-            maxY = round(maxY + dist_left/2)
-    else:
-        inside = False
-
-    # Shift the box if it's close to the edge
-    minX, minY = shift(size, minX, minY)
-
-    # print("MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
-
-    # Shrink/move the box horizontally if it is bigger than the picture
-    if (minX < 0 or minX + target_size[0] > size[0]):
-        print("No possible box of size 512,512 possible")
-        maxX = size[0]
-        minX = size[0] - target_size[0]
-        if target_size[0] >= size[0]:
-            minX = 0
-    else:
-        maxX = minX + target_size[0]
-
-    # Shrink/move the box vertically if it is bigger than the picture
-    if (minY < 0 or minY + target_size[1] > size[1]):
-        maxY = size[1]
-        minY = size[1] - target_size[1]
-        if target_size[1] >= size[1]:
-            minY = 0
-    else:
-        maxY = minY + target_size[1]
-
-    return [inside, (minX, minY, maxX, maxY)]
-
-# Shifts the x and y if it's too close to the edge for target_size not to be applicable
-# Does not reshape the box if the target_size is greater than size of the picture
-def shift(size, x, y, target_size=(512, 512)):
-
-    if x < 0:
-        x = 0
-    if (x + target_size[0]) > size[0]:
-        x = size[0] - target_size[0]
-
-    if y < 0:
-        y = 0
-    if (y + target_size[1]) > size[1]:
-        y = size[1] - target_size[1]
-
-    return x, y
+def is_right_color(pixel, r2, g2, b2):
+    r1, g1, b1 = pixel
+    return r1 == r2 and g1 == g2 and b1 == b2
 
 # Draws boxes around the found censor regions.
 if __name__ == '__main__':
-    image = Image.open(r'')
+    image = Image.open(r'D:\VirtualPython\venv\DeepCreamPy\decensor_input\mermaid_censored.png')
     no_alpha_image = image.convert('RGB')
     draw = ImageDraw.Draw(no_alpha_image)
     
     ### Original
     # for region in find_regions(no_alpha_image, [0, 255, 0]):
-    #     draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
+    #     draw.rectangle(expand_bounding(no_alpha_image, region), outline=(0, 255, 0))
     # no_alpha_image.show()
     ### END OF ORIGINAL
 
     ### With new mask region finder
-    # ori_array = np.asarray(no_alpha_image)
-    # ori_array = np.array(ori_array / 255.0)
-    # ori_array = np.expand_dims(ori_array, axis=0)
-    # mask = get_mask(ori_array, [0.0, 1.0, 0.0])
-    # regions = region_by_mask(mask)
-    # for region in regions:
-    #     draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
-    # no_alpha_image.show()
-    ### END OF NEW MASK REGION FINDER
-
-    ### Using big boxes and new region finder
-    width, height = no_alpha_image.size
     ori_array = np.asarray(no_alpha_image)
     ori_array = np.array(ori_array / 255.0)
     ori_array = np.expand_dims(ori_array, axis=0)
-
     mask = get_mask(ori_array, [0.0, 1.0, 0.0])
-
-    # Find all the masked regions
-    regions = region_by_mask(mask)
-
-    box_bounds = []
-    # Group boxes into a bigger box that has size target_size (default: 512x512)
-    for region_counter, region in enumerate(regions, 1):
-        bounding_box = expand_bounding_mk2(no_alpha_image, region, expand_factor=1.25, min_size=64)
-
-        if (len(box_bounds) == 0):
-            boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
-            if (boxCheck[0]):
-                box_bounds.append([boxCheck[1], [bounding_box], [region]])
-            else:
-                print("Censor region exceeds boundary: {}".format(bounding_box))
-            continue    
-        for i in range(len(box_bounds)):
-            boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
-            if (boxCheck[0]):
-                box_bounds[i][0] = boxCheck[1]
-                box_bounds[i][1].append(bounding_box)
-                box_bounds[i][2].append(region)
-                break
-            else:
-                if (i == len(box_bounds) - 1):
-                    boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
-                    if (boxCheck[0]):
-                        box_bounds.append([boxCheck[1], [bounding_box], [region]])
-                    else:
-                        print("Censor region exceeds boundary: {}".format(bounding_box))
-
-    # Iterate over the big boxes and draw them to the picture
-    for indx, region in enumerate(box_bounds):
-        # Alternate colors
-        c = (255 * (0 if (indx) % 3 == 0 else 1), 255 * (0 if (indx + 1) % 3 == 0 else 1), 255 * (0 if (indx + 2) % 3 == 0 else 1))
-        # print(indx, c)
-
-        # Display the big box
-        draw.rectangle(region[0], outline=c, width=5)
-
-        # Display all the boxes that are grouped in the big box, uncomment to show
-        for box in region[1]:
-            draw.rectangle(expand_bounding_mk2(no_alpha_image, box, expand_factor=1.25), outline=c, width=3)
+    regions = find_regions(mask)
+    for region in regions:
+        draw.rectangle(expand_bounding(no_alpha_image, region), outline=(0, 255, 0))
     no_alpha_image.show()
-    ### END OF BIG BOXES + REGION FINDER
+    ### END OF NEW MASK REGION FINDER

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -1,7 +1,10 @@
 from PIL import Image, ImageDraw
 import numpy as np
 
-
+# Return a mask based off the specified color
+# Color should have a shape of (r, g, b) and a float value from 0.0 to 1.0
+# Colored should be the image in array form, with expanded dimensions of axis=0,
+# and the array has values from 0.0 to 1.0, same as color array.
 def get_mask(colored, color):
     mask = np.ones(colored.shape, np.uint8)
     i, j = np.where(np.all(colored[0] == color, axis=-1))
@@ -13,12 +16,17 @@ def image_to_array(image):
     array = np.asarray(image)
     return np.array(array / 255.0)
 
-
+# Find all the regions of the masked picture
+# All marked regions should have the value 0, all else should be 1
 def region_by_mask(mask):
+    # Gets all of the coordinates where the mask exists
     i, j = np.where(np.all(mask[0], axis=-1) == 0)
     if len(i) == 0:
         return []
+    # Creates a tuple of the coordinates
     coords = [coord for coord in zip(j, i)]
+
+    # Creates a dictionary with the coordinates as both key and value.
     neighbors = dict((y, {y}) for y in coords)
 
     for x, y in neighbors:
@@ -47,168 +55,7 @@ def region_by_mask(mask):
     regions.sort(key=len, reverse=True)
     return regions
 
-# find strongly connected components with the mask color
-
-
-def find_regions(image, mask_color):
-    pixel = image.load()
-    neighbors = dict()
-    width, height = image.size
-    for x in range(width):
-        for y in range(height):
-            if is_right_color(pixel[x,y], *mask_color):
-                neighbors[x, y] = {(x,y)}
-    for x, y in neighbors:
-        candidates = (x + 1, y), (x, y + 1)
-        for candidate in candidates:
-            if candidate in neighbors:
-                neighbors[x, y].add(candidate)
-                neighbors[candidate].add((x, y))
-    closed_list = set()
-
-    def connected_component(pixel):
-        region = set()
-        open_list = {pixel}
-        while open_list:
-            pixel = open_list.pop()
-            closed_list.add(pixel)
-            open_list |= neighbors[pixel] - closed_list
-            region.add(pixel)
-        return region
-
-    regions = []
-    for pixel in neighbors:
-        if pixel not in closed_list:
-            regions.append(connected_component(pixel))
-    regions.sort(key = len, reverse = True)
-    return regions
-
-
-def find_color_regions(image, target_color=(0, 0, 0), threshhold=(1, 1)):
-    target_color = np.array(target_color) * 255.0
-    # print(target_color)
-    low_t = (target_color[0] - threshhold[0], target_color[1] - threshhold[0], target_color[2] - threshhold[0])
-    high_t = (target_color[0] + threshhold[1], target_color[1] + threshhold[1], target_color[2] + threshhold[1])
-    # print(low_t, high_t)
-    pixel = image.load()
-    neighbors = dict()
-    width, height = image.size
-    for x in range(width):
-        for y in range(height):
-            r, g, b = pixel[x, y]
-            if low_t[0] <= r and r <= high_t[0] and \
-               low_t[1] <= g and g <= high_t[1] and \
-               low_t[2] <= b and b <= high_t[2]:
-                neighbors[x, y] = {(x, y)}
-    for x, y in neighbors:
-        candidates = []
-        candidates = (x + 1, y), (x, y + 1)
-        for candidate in candidates:
-            if candidate in neighbors:
-                neighbors[x, y].add(candidate)
-                neighbors[candidate].add((x, y))
-    closed_list = set()
-
-    def connected_component(pixel):
-        region = set()
-        open_list = {pixel}
-        while open_list:
-            pixel = open_list.pop()
-            closed_list.add(pixel)
-            open_list |= neighbors[pixel] - closed_list
-            region.add(pixel)
-        return region
-
-    regions = []
-    for pixel in neighbors:
-        if pixel not in closed_list:
-            regions.append(connected_component(pixel))
-    regions.sort(key=len, reverse=True)
-    return regions
-
-# risk of box being bigger than the image
-def expand_bounding(img, region, expand_factor=1.5, min_size = 256):
-    #expand bounding box to capture more context
-    x, y = zip(*region)
-    min_x, min_y, max_x, max_y = min(x), min(y), max(x), max(y)
-    width, height = img.size
-    width_center = width//2
-    height_center = height//2
-    bb_width = max_x - min_x
-    bb_height = max_y - min_y
-    x_center = (min_x + max_x)//2
-    y_center = (min_y + max_y)//2
-    current_size = max(bb_width, bb_height)
-    current_size  = int(current_size * expand_factor)
-    max_size = min(width, height)
-    if current_size > max_size:
-        current_size = max_size
-    elif current_size < min_size:
-        current_size = min_size
-    x1 = x_center - current_size//2
-    x2 = x_center + current_size//2
-    y1 = y_center - current_size//2
-    y2 = y_center + current_size//2
-    x1_square = x1
-    y1_square = y1
-    x2_square = x2
-    y2_square = y2
-    #move bounding boxes that are partially outside of the image inside the image
-    if (y1_square < 0 or y2_square > (height - 1)) and (x1_square < 0 or x2_square > (width - 1)):
-        #conservative square region
-        if x1_square < 0 and y1_square < 0:
-            x1_square = 0
-            y1_square = 0
-            x2_square = current_size
-            y2_square = current_size
-        elif x2_square > (width - 1) and y1_square < 0:
-            x1_square = width - current_size - 1
-            y1_square = 0
-            x2_square = width - 1
-            y2_square = current_size
-        elif x1_square < 0 and y2_square > (height - 1):
-            x1_square = 0
-            y1_square = height - current_size - 1
-            x2_square = current_size
-            y2_square = height - 1
-        elif x2_square > (width - 1) and y2_square > (height - 1):
-            x1_square = width - current_size - 1
-            y1_square = height - current_size - 1
-            x2_square = width - 1
-            y2_square = height - 1
-        else:
-            x1_square = x1
-            y1_square = y1
-            x2_square = x2
-            y2_square = y2
-    else:
-        if x1_square < 0:
-            difference = x1_square
-            x1_square -= difference
-            x2_square -= difference
-        if x2_square > (width - 1):
-            difference = x2_square - width + 1
-            x1_square -= difference
-            x2_square -= difference
-        if y1_square < 0:
-            difference = y1_square
-            y1_square -= difference
-            y2_square -= difference
-        if y2_square > (height - 1):
-            difference = y2_square - height + 1
-            y1_square -= difference
-            y2_square -= difference
-    # if y1_square < 0 or y2_square > (height - 1):
-
-    #if bounding box goes outside of the image for some reason, set bounds to original, unexpanded values
-    #print(width, height)
-    if x2_square > width or y2_square > height:
-        print("bounding box out of bounds!")
-        print(x1_square, y1_square, x2_square, y2_square)
-        x1_square, y1_square, x2_square, y2_square = min_x, min_y, max_x, max_y
-    return x1_square, y1_square, x2_square, y2_square
-
-
+# Expand the box surrounding the region area.
 def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=512):
     # expand bounding box to capture more context
     if not isinstance(region, set) and len(region) == 4:
@@ -216,8 +63,6 @@ def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=
     else:
         x, y = zip(*region)
         min_x, min_y, max_x, max_y = min(x), min(y), max(x), max(y)
-
-    # print("MinX {}, MinY {}, MaxX {}, MaxY, {}".format(min_x, min_y, max_x, max_y))
 
     width, height = img.size
     bb_width = max_x - min_x
@@ -292,24 +137,27 @@ def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=
             y1_square -= difference
             y2_square -= difference
 
+    # If the box is out of bounds, return to the original coordinates
     if x2_square > width or y2_square > height:
         print("bounding box out of bounds!")
         print(x1_square, y1_square, x2_square, y2_square)
         x1_square, y1_square, x2_square, y2_square = min_x, min_y, max_x, max_y
     return int(x1_square), int(y1_square), int(x2_square), int(y2_square)
 
-
-def bounding_box_check_mk2(size, box1, box2, target_size=(512, 512)):
-    # expand bounding box to capture more context
-    #    print("Creating new box for box1: {b1}, and box2: {b2}".format(b1=box1, b2=box2))
+# Creates a new big box around the specified box. 
+# Size is the size of the picture, and not the box, which is meant to limit the coordinates of the box
+# as to not go outside of the picture.
+# Index 0 of the return array is a boolean mentioning if the box is too big to fit in the picture (False if too big).
+def bounding_box_check_mk2(size, box, target_size=(512, 512)):
     inside = True
-    minX = min(box1[0], box1[2], box2[0], box2[2])
-    maxX = max(box1[0], box1[2], box2[0], box2[2])
-    minY = min(box1[1], box1[3], box2[1], box2[3])
-    maxY = max(box1[1], box1[3], box2[1], box2[3])
+    # Get the boundaries of the box
+    minX = min(box[0], box[2])
+    maxX = max(box[0], box[2])
+    minY = min(box[1], box[3])
+    maxY = max(box[1], box[3])
 
-#    print("BEFORE -- MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
-
+    # If the box has a width less than or equal to the target size (512, 512)
+    # a bigger box is created, centered around it
     b_width = maxX - minX
     if b_width <= target_size[0]:
         dist_left = target_size[0] - b_width
@@ -317,8 +165,8 @@ def bounding_box_check_mk2(size, box1, box2, target_size=(512, 512)):
             minX = round(minX - dist_left/2)
             maxX = round(maxX + dist_left/2)
     else:
+        print('Censor region is too big')
         inside = False
-#        print(b_width)
 
     b_height = maxY - minY
     if b_height <= target_size[1]:
@@ -327,35 +175,44 @@ def bounding_box_check_mk2(size, box1, box2, target_size=(512, 512)):
             minY = round(minY - dist_left/2)
             maxY = round(maxY + dist_left/2)
     else:
+        print('Censor region is too big')
         inside = False
 
+    # This shifts the box so that it does not go outside of the picture
     minX, minY = shift(size, minX, minY)
 
-#    print("MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
-
+    # Shrink/move the box horizontally if it is bigger than the picture
     if (minX < 0 or minX + target_size[0] > size[0]):
         print("No possible box of size 512,512 possible")
         maxX = size[0]
     else:
         maxX = minX + target_size[0]
 
+    minX = max(0, minX)
+
+    # Shrink/move the box vertically if it is bigger than the picture
     if (minY < 0 or minY + target_size[1] > size[1]):
-        maxY = size[0]
+        maxY = size[1]
     else:
         maxY = minY + target_size[1]
 
+    minY = max(0, minY)
+
     return [inside, (minX, minY, maxX, maxY)]
 
-
+# Check if box1 fits into big_box by checking if it is within range of all other boxes.
+# Size is the size of the picture and not the size of the box.
 def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
     inside = True
 
+    # Initialize maxX,maxY,minX,minY
     maxX = max(box1[0], box1[2])
     maxY = max(box1[1], box1[3])
 
     minX = min(box1[0], box1[2])
     minY = min(box1[1], box1[3])
 
+    # Check all the boxes for the correct min/max values
     for box in boxes:
         maxX = max(maxX, box[0], box[2])
         maxY = max(maxY, box[1], box[3])
@@ -363,7 +220,11 @@ def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
         minX = min(minX, box[0], box[2])
         minY = min(minY, box[1], box[3])
 
+    # Get the total width of the new big box
     b_width = maxX - minX
+
+    # If the new big box has a width less than or equal to the target size (512, 512)
+    # the new box fits into the group, and the big box can be moved accordingly
     if b_width <= target_size[0]:
         dist_left = target_size[0] - b_width
         if dist_left != 0:
@@ -372,6 +233,7 @@ def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
     else:
         inside = False
 
+    # Same deal for the height as for the width above
     b_height = maxY - minY
     if b_height <= target_size[1]:
         dist_left = target_size[1] - b_height
@@ -381,10 +243,12 @@ def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
     else:
         inside = False
 
+    # Shift the box if it's close to the edge
     minX, minY = shift(size, minX, minY)
 
     # print("MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
 
+    # Shrink/move the box horizontally if it is bigger than the picture
     if (minX < 0 or minX + target_size[0] > size[0]):
         print("No possible box of size 512,512 possible")
         maxX = size[0]
@@ -394,6 +258,7 @@ def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
     else:
         maxX = minX + target_size[0]
 
+    # Shrink/move the box vertically if it is bigger than the picture
     if (minY < 0 or minY + target_size[1] > size[1]):
         maxY = size[1]
         minY = size[1] - target_size[1]
@@ -404,7 +269,8 @@ def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
 
     return [inside, (minX, minY, maxX, maxY)]
 
-
+# Shifts the x and y if it's too close to the edge for target_size not to be applicable
+# Does not reshape the box if the target_size is greater than size of the picture
 def shift(size, x, y, target_size=(512, 512)):
 
     if x < 0:
@@ -419,34 +285,9 @@ def shift(size, x, y, target_size=(512, 512)):
 
     return x, y
 
-
-def center(size, X, Y, target_size=(512, 512)):
-    centerX = X / 2
-    centerY = Y / 2
-
-    if (centerX + 256 > size[0]):
-        centerX = size[0] - target_size[0]/2
-    if (centerX - 256 < 0):
-        centerX = size[0] + target_size[0]/2
-
-    if (centerY + 256 > size[1]):
-        centerY = size[1] - target_size[1]/2
-    if (centerY - 256 < 0):
-        centerY = size[1] + target_size[1]/2
-
-    return round(centerX), round(centerY)
-
-
-def is_green(pixel):
-    r, g, b = pixel
-    return r == 0 and g == 255 and b == 0
-
-def is_right_color(pixel, r2, g2, b2):
-    r1, g1, b1 = pixel
-    return r1 == r2 and g1 == g2 and b1 == b2
-
+# Draws boxes around the found censor regions.
 if __name__ == '__main__':
-    image = Image.open('')
+    image = Image.open(r'')
     no_alpha_image = image.convert('RGB')
     draw = ImageDraw.Draw(no_alpha_image)
     
@@ -457,65 +298,65 @@ if __name__ == '__main__':
     ### END OF ORIGINAL
 
     ### With new mask region finder
-    ori_array = np.asarray(no_alpha_image)
-    ori_array = np.array(ori_array / 255.0)
-    ori_array = np.expand_dims(ori_array, axis=0)
-    mask = get_mask(ori_array, [0.0, 1.0, 0.0])
-    regions = region_by_mask(mask)
-    for region in regions:
-        draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
-    no_alpha_image.show()
-    ### END OF NEW MASK REGION FINDER
-
-    ### Using big boxes and new region finder
-    # width, height = no_alpha_image.size
     # ori_array = np.asarray(no_alpha_image)
     # ori_array = np.array(ori_array / 255.0)
     # ori_array = np.expand_dims(ori_array, axis=0)
-
     # mask = get_mask(ori_array, [0.0, 1.0, 0.0])
-
     # regions = region_by_mask(mask)
-
-    # box_bounds = []
-    # # Group boxes into a bigger box that has size 512x512
-    # for region_counter, region in enumerate(regions, 1):
-    #     bounding_box = expand_bounding_mk2(no_alpha_image, region, expand_factor=1.25, min_size=64)
-
-    #     if (len(box_bounds) == 0):
-    #         boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
-    #         if (boxCheck[0]):
-    #             box_bounds.append([boxCheck[1], [bounding_box], [region]])
-    #             continue
-    #         else:
-    #             print("Could not create bounding box for censored area. Aborting.")
-    #             break
-    #     for i in range(len(box_bounds)):
-    #         boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
-    #         if (boxCheck[0]):
-    #             box_bounds[i][0] = boxCheck[1]
-    #             box_bounds[i][1].append(bounding_box)
-    #             box_bounds[i][2].append(region)
-    #             break
-    #         else:
-    #             if (i == len(box_bounds) - 1):
-    #                 boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
-    #                 if (boxCheck[0]):
-    #                     box_bounds.append([boxCheck[1], [bounding_box], [region]])
-    #                 else:
-    #                     print("Could not create bounding box for censored area. Aborting.")
-    #                     break
-
-    # for indx, region in enumerate(box_bounds):
-    #     # Alternate colors
-    #     c = (255 * (0 if (indx) % 3 == 0 else 1), 255 * (0 if (indx + 1) % 3 == 0 else 1), 255 * (0 if (indx + 2) % 3 == 0 else 1))
-    #     # print(indx, c)
-
-    #     # Display the big box
-    #     draw.rectangle(region[0], outline=c, width=5)
-
-    #     # Display all the boxes that are grouped in the big box, uncomment to show
-    #     # for box in region[1]:
-    #         # draw.rectangle(expand_bounding_mk2(no_alpha_image, box, expand_factor=1.25), outline=c, width=3)
+    # for region in regions:
+    #     draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
     # no_alpha_image.show()
+    ### END OF NEW MASK REGION FINDER
+
+    ### Using big boxes and new region finder
+    width, height = no_alpha_image.size
+    ori_array = np.asarray(no_alpha_image)
+    ori_array = np.array(ori_array / 255.0)
+    ori_array = np.expand_dims(ori_array, axis=0)
+
+    mask = get_mask(ori_array, [0.0, 1.0, 0.0])
+
+    # Find all the masked regions
+    regions = region_by_mask(mask)
+
+    box_bounds = []
+    # Group boxes into a bigger box that has size target_size (default: 512x512)
+    for region_counter, region in enumerate(regions, 1):
+        bounding_box = expand_bounding_mk2(no_alpha_image, region, expand_factor=1.25, min_size=64)
+
+        if (len(box_bounds) == 0):
+            boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
+            if (boxCheck[0]):
+                box_bounds.append([boxCheck[1], [bounding_box], [region]])
+            else:
+                print("Censor region exceeds boundary: {}".format(bounding_box))
+            continue    
+        for i in range(len(box_bounds)):
+            boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
+            if (boxCheck[0]):
+                box_bounds[i][0] = boxCheck[1]
+                box_bounds[i][1].append(bounding_box)
+                box_bounds[i][2].append(region)
+                break
+            else:
+                if (i == len(box_bounds) - 1):
+                    boxCheck = bounding_box_check_mk2((width, height), bounding_box, target_size=(512, 512))
+                    if (boxCheck[0]):
+                        box_bounds.append([boxCheck[1], [bounding_box], [region]])
+                    else:
+                        print("Censor region exceeds boundary: {}".format(bounding_box))
+
+    # Iterate over the big boxes and draw them to the picture
+    for indx, region in enumerate(box_bounds):
+        # Alternate colors
+        c = (255 * (0 if (indx) % 3 == 0 else 1), 255 * (0 if (indx + 1) % 3 == 0 else 1), 255 * (0 if (indx + 2) % 3 == 0 else 1))
+        # print(indx, c)
+
+        # Display the big box
+        draw.rectangle(region[0], outline=c, width=5)
+
+        # Display all the boxes that are grouped in the big box, uncomment to show
+        for box in region[1]:
+            draw.rectangle(expand_bounding_mk2(no_alpha_image, box, expand_factor=1.25), outline=c, width=3)
+    no_alpha_image.show()
     ### END OF BIG BOXES + REGION FINDER

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -1,12 +1,55 @@
-import numpy as np
 from PIL import Image, ImageDraw
+import numpy as np
 
-#convert PIL image to numpy array
+
+def get_mask(colored, color):
+    mask = np.ones(colored.shape, np.uint8)
+    i, j = np.where(np.all(colored[0] == color, axis=-1))
+    mask[0, i, j] = 0
+    return mask
+
+
 def image_to_array(image):
     array = np.asarray(image)
     return np.array(array / 255.0)
 
-#find strongly connected components with the mask color
+
+def region_by_mask(mask):
+    i, j = np.where(np.all(mask[0], axis=-1) == 0)
+    if len(i) == 0:
+        return []
+    coords = [coord for coord in zip(j, i)]
+    neighbors = dict((y, {y}) for y in coords)
+
+    for x, y in neighbors:
+        candidates = (x + 1, y), (x, y + 1)
+        for candidate in candidates:
+            if candidate in neighbors:
+                neighbors[x, y].add(candidate)
+                neighbors[candidate].add((x, y))
+
+    closed_list = set()
+
+    def connected_component(pixel):
+        region = set()
+        open_list = {pixel}
+        while open_list:
+            pixel = open_list.pop()
+            closed_list.add(pixel)
+            open_list |= neighbors[pixel] - closed_list
+            region.add(pixel)
+        return region
+
+    regions = []
+    for pixel in neighbors:
+        if pixel not in closed_list:
+            regions.append(connected_component(pixel))
+    regions.sort(key=len, reverse=True)
+    return regions
+
+# find strongly connected components with the mask color
+
+
 def find_regions(image, mask_color):
     pixel = image.load()
     neighbors = dict()
@@ -38,6 +81,49 @@ def find_regions(image, mask_color):
         if pixel not in closed_list:
             regions.append(connected_component(pixel))
     regions.sort(key = len, reverse = True)
+    return regions
+
+
+def find_color_regions(image, target_color=(0, 0, 0), threshhold=(1, 1)):
+    target_color = np.array(target_color) * 255.0
+    # print(target_color)
+    low_t = (target_color[0] - threshhold[0], target_color[1] - threshhold[0], target_color[2] - threshhold[0])
+    high_t = (target_color[0] + threshhold[1], target_color[1] + threshhold[1], target_color[2] + threshhold[1])
+    # print(low_t, high_t)
+    pixel = image.load()
+    neighbors = dict()
+    width, height = image.size
+    for x in range(width):
+        for y in range(height):
+            r, g, b = pixel[x, y]
+            if low_t[0] <= r and r <= high_t[0] and \
+               low_t[1] <= g and g <= high_t[1] and \
+               low_t[2] <= b and b <= high_t[2]:
+                neighbors[x, y] = {(x, y)}
+    for x, y in neighbors:
+        candidates = []
+        candidates = (x + 1, y), (x, y + 1)
+        for candidate in candidates:
+            if candidate in neighbors:
+                neighbors[x, y].add(candidate)
+                neighbors[candidate].add((x, y))
+    closed_list = set()
+
+    def connected_component(pixel):
+        region = set()
+        open_list = {pixel}
+        while open_list:
+            pixel = open_list.pop()
+            closed_list.add(pixel)
+            open_list |= neighbors[pixel] - closed_list
+            region.add(pixel)
+        return region
+
+    regions = []
+    for pixel in neighbors:
+        if pixel not in closed_list:
+            regions.append(connected_component(pixel))
+    regions.sort(key=len, reverse=True)
     return regions
 
 # risk of box being bigger than the image
@@ -122,6 +208,239 @@ def expand_bounding(img, region, expand_factor=1.5, min_size = 256):
         x1_square, y1_square, x2_square, y2_square = min_x, min_y, max_x, max_y
     return x1_square, y1_square, x2_square, y2_square
 
+
+def expand_bounding_mk2(img, region, expand_factor=1.50, min_size=256, max_size=512):
+    # expand bounding box to capture more context
+    if not isinstance(region, set) and len(region) == 4:
+        min_x, min_y, max_x, max_y = region[0], region[1], region[2], region[3]
+    else:
+        x, y = zip(*region)
+        min_x, min_y, max_x, max_y = min(x), min(y), max(x), max(y)
+
+    # print("MinX {}, MinY {}, MaxX {}, MaxY, {}".format(min_x, min_y, max_x, max_y))
+
+    width, height = img.size
+    bb_width = max_x - min_x
+    bb_height = max_y - min_y
+    x_center = (min_x + max_x)//2
+    y_center = (min_y + max_y)//2
+    current_size = max(bb_width, bb_height)
+    current_size = int(current_size * expand_factor)
+    bb_width = int(bb_width * expand_factor)
+    bb_height = int(bb_height * expand_factor)
+    if bb_width > max_size:
+        bb_width = max_size
+    if bb_width < min_size:
+        bb_width = min_size
+
+    if bb_height > max_size:
+        bb_height = max_size
+    if bb_height < min_size:
+        bb_height = min_size
+
+    x1 = x_center - bb_width//2
+    x2 = x_center + bb_width//2
+    y1 = y_center - bb_height//2
+    y2 = y_center + bb_height//2
+    x1_square = x1
+    y1_square = y1
+    x2_square = x2
+    y2_square = y2
+
+    if (y1_square < 0 or y2_square > (height - 1)) and (x1_square < 0 or x2_square > (width - 1)):
+        # conservative square region
+        if x1_square < 0 and y1_square < 0:
+            x1_square = 0
+            y1_square = 0
+            x2_square = bb_width
+            y2_square = bb_height
+        elif x2_square > (width - 1) and y1_square < 0:
+            x1_square = width - bb_width - 1
+            y1_square = 0
+            x2_square = width - 1
+            y2_square = bb_height
+        elif x1_square < 0 and y2_square > (height - 1):
+            x1_square = 0
+            y1_square = height - bb_height - 1
+            x2_square = bb_width
+            y2_square = height - 1
+        elif x2_square > (width - 1) and y2_square > (height - 1):
+            x1_square = width - bb_width - 1
+            y1_square = height - bb_height - 1
+            x2_square = width - 1
+            y2_square = height - 1
+        else:
+            x1_square = x1
+            y1_square = y1
+            x2_square = x2
+            y2_square = y2
+    else:
+        if x1_square < 0:
+            difference = x1_square
+            x1_square -= difference
+            x2_square -= difference
+        if x2_square > (width - 1):
+            difference = x2_square - width + 1
+            x1_square -= difference
+            x2_square -= difference
+        if y1_square < 0:
+            difference = y1_square
+            y1_square -= difference
+            y2_square -= difference
+        if y2_square > (height - 1):
+            difference = y2_square - height + 1
+            y1_square -= difference
+            y2_square -= difference
+
+    if x2_square > width or y2_square > height:
+        print("bounding box out of bounds!")
+        print(x1_square, y1_square, x2_square, y2_square)
+        x1_square, y1_square, x2_square, y2_square = min_x, min_y, max_x, max_y
+    return int(x1_square), int(y1_square), int(x2_square), int(y2_square)
+
+
+def bounding_box_check_mk2(size, box1, box2, target_size=(512, 512)):
+    # expand bounding box to capture more context
+    #    print("Creating new box for box1: {b1}, and box2: {b2}".format(b1=box1, b2=box2))
+    inside = True
+    minX = min(box1[0], box1[2], box2[0], box2[2])
+    maxX = max(box1[0], box1[2], box2[0], box2[2])
+    minY = min(box1[1], box1[3], box2[1], box2[3])
+    maxY = max(box1[1], box1[3], box2[1], box2[3])
+
+#    print("BEFORE -- MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
+
+    b_width = maxX - minX
+    if b_width <= target_size[0]:
+        dist_left = target_size[0] - b_width
+        if dist_left != 0:
+            minX = round(minX - dist_left/2)
+            maxX = round(maxX + dist_left/2)
+    else:
+        inside = False
+#        print(b_width)
+
+    b_height = maxY - minY
+    if b_height <= target_size[1]:
+        dist_left = target_size[1] - b_height
+        if dist_left != 0:
+            minY = round(minY - dist_left/2)
+            maxY = round(maxY + dist_left/2)
+    else:
+        inside = False
+
+    minX, minY = shift(size, minX, minY)
+
+#    print("MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
+
+    if (minX < 0 or minX + target_size[0] > size[0]):
+        print("No possible box of size 512,512 possible")
+        maxX = size[0]
+    else:
+        maxX = minX + target_size[0]
+
+    if (minY < 0 or minY + target_size[1] > size[1]):
+        maxY = size[0]
+    else:
+        maxY = minY + target_size[1]
+
+    return [inside, (minX, minY, maxX, maxY)]
+
+
+def big_bound_check_mk2(size, big_box, box1, boxes, target_size=(512, 512)):
+    inside = True
+
+    maxX = max(box1[0], box1[2])
+    maxY = max(box1[1], box1[3])
+
+    minX = min(box1[0], box1[2])
+    minY = min(box1[1], box1[3])
+
+    for box in boxes:
+        maxX = max(maxX, box[0], box[2])
+        maxY = max(maxY, box[1], box[3])
+
+        minX = min(minX, box[0], box[2])
+        minY = min(minY, box[1], box[3])
+
+    b_width = maxX - minX
+    if b_width <= target_size[0]:
+        dist_left = target_size[0] - b_width
+        if dist_left != 0:
+            minX = round(minX - dist_left/2)
+            maxX = round(maxX + dist_left/2)
+    else:
+        inside = False
+
+    b_height = maxY - minY
+    if b_height <= target_size[1]:
+        dist_left = target_size[1] - b_height
+        if dist_left != 0:
+            minY = round(minY - dist_left/2)
+            maxY = round(maxY + dist_left/2)
+    else:
+        inside = False
+
+    minX, minY = shift(size, minX, minY)
+
+    # print("MaxX: {maxx}, MinX: {minx}, MaxY: {maxy}, MinY: {miny}".format(maxx=maxX, minx=minX, maxy=maxY, miny=minY))
+
+    if (minX < 0 or minX + target_size[0] > size[0]):
+        print("No possible box of size 512,512 possible")
+        maxX = size[0]
+        minX = size[0] - target_size[0]
+        if target_size[0] >= size[0]:
+            minX = 0
+    else:
+        maxX = minX + target_size[0]
+
+    if (minY < 0 or minY + target_size[1] > size[1]):
+        maxY = size[1]
+        minY = size[1] - target_size[1]
+        if target_size[1] >= size[1]:
+            minY = 0
+    else:
+        maxY = minY + target_size[1]
+
+    return [inside, (minX, minY, maxX, maxY)]
+
+
+def shift(size, x, y, target_size=(512, 512)):
+
+    if x < 0:
+        x = 0
+    if (x + target_size[0]) > size[0]:
+        x = size[0] - target_size[0]
+
+    if y < 0:
+        y = 0
+    if (y + target_size[1]) > size[1]:
+        y = size[1] - target_size[1]
+
+    return x, y
+
+
+def center(size, X, Y, target_size=(512, 512)):
+    centerX = X / 2
+    centerY = Y / 2
+
+    if (centerX + 256 > size[0]):
+        centerX = size[0] - target_size[0]/2
+    if (centerX - 256 < 0):
+        centerX = size[0] + target_size[0]/2
+
+    if (centerY + 256 > size[1]):
+        centerY = size[1] - target_size[1]/2
+    if (centerY - 256 < 0):
+        centerY = size[1] + target_size[1]/2
+
+    return round(centerX), round(centerY)
+
+
+def is_green(pixel):
+    r, g, b = pixel
+    return r == 0 and g == 255 and b == 0
+
 def is_right_color(pixel, r2, g2, b2):
     r1, g1, b1 = pixel
     return r1 == r2 and g1 == g2 and b1 == b2
@@ -130,6 +449,73 @@ if __name__ == '__main__':
     image = Image.open('')
     no_alpha_image = image.convert('RGB')
     draw = ImageDraw.Draw(no_alpha_image)
-    for region in find_regions(no_alpha_image, [0,255,0]):
-        draw.rectangle(expand_bounding(no_alpha_image, region), outline=(0, 255, 0))
+    
+    ### Original
+    # for region in find_regions(no_alpha_image, [0, 255, 0]):
+    #     draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
+    # no_alpha_image.show()
+    ### END OF ORIGINAL
+
+    ### With new mask region finder
+    ori_array = np.asarray(no_alpha_image)
+    ori_array = np.array(ori_array / 255.0)
+    ori_array = np.expand_dims(ori_array, axis=0)
+    mask = get_mask(ori_array, [0.0, 1.0, 0.0])
+    regions = region_by_mask(mask)
+    for region in regions:
+        draw.rectangle(expand_bounding_mk2(no_alpha_image, region), outline=(0, 255, 0))
     no_alpha_image.show()
+    ### END OF NEW MASK REGION FINDER
+
+    ### Using big boxes and new region finder
+    # width, height = no_alpha_image.size
+    # ori_array = np.asarray(no_alpha_image)
+    # ori_array = np.array(ori_array / 255.0)
+    # ori_array = np.expand_dims(ori_array, axis=0)
+
+    # mask = get_mask(ori_array, [0.0, 1.0, 0.0])
+
+    # regions = region_by_mask(mask)
+
+    # box_bounds = []
+    # # Group boxes into a bigger box that has size 512x512
+    # for region_counter, region in enumerate(regions, 1):
+    #     bounding_box = expand_bounding_mk2(no_alpha_image, region, expand_factor=1.25, min_size=64)
+
+    #     if (len(box_bounds) == 0):
+    #         boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+    #         if (boxCheck[0]):
+    #             box_bounds.append([boxCheck[1], [bounding_box], [region]])
+    #             continue
+    #         else:
+    #             print("Could not create bounding box for censored area. Aborting.")
+    #             break
+    #     for i in range(len(box_bounds)):
+    #         boxCheck = big_bound_check_mk2((width, height), box_bounds[i][0], bounding_box, box_bounds[i][1], (512, 512))
+    #         if (boxCheck[0]):
+    #             box_bounds[i][0] = boxCheck[1]
+    #             box_bounds[i][1].append(bounding_box)
+    #             box_bounds[i][2].append(region)
+    #             break
+    #         else:
+    #             if (i == len(box_bounds) - 1):
+    #                 boxCheck = bounding_box_check_mk2((width, height), bounding_box, bounding_box, target_size=(512, 512))
+    #                 if (boxCheck[0]):
+    #                     box_bounds.append([boxCheck[1], [bounding_box], [region]])
+    #                 else:
+    #                     print("Could not create bounding box for censored area. Aborting.")
+    #                     break
+
+    # for indx, region in enumerate(box_bounds):
+    #     # Alternate colors
+    #     c = (255 * (0 if (indx) % 3 == 0 else 1), 255 * (0 if (indx + 1) % 3 == 0 else 1), 255 * (0 if (indx + 2) % 3 == 0 else 1))
+    #     # print(indx, c)
+
+    #     # Display the big box
+    #     draw.rectangle(region[0], outline=c, width=5)
+
+    #     # Display all the boxes that are grouped in the big box, uncomment to show
+    #     # for box in region[1]:
+    #         # draw.rectangle(expand_bounding_mk2(no_alpha_image, box, expand_factor=1.25), outline=c, width=3)
+    # no_alpha_image.show()
+    ### END OF BIG BOXES + REGION FINDER


### PR DESCRIPTION
Don't know if you're working on DCPv1 anymore, or if you even want these, but here are some of my changes. I would've reached out through email/dm if I could've found any, but I guess this will do.

The first major change to the code is the new region finding (region_by_mask), which is based on the mask array instead of the color. It's faster than the original region finding, at least in all the images I've tried. There might be an even better solution to this, but I don't really know how to handle lists/dicts in Python so this is what I got.

The other change is region grouping, which basically groups all the nearby found regions into a 512x512 box instead of resizing all regions individually and then using predict on each. This means that there will be some changes in how the decensoring turns out, but it will also be faster or at least equally as fast. 
On my computer, the mermaid picture looks a bit worse with the grouping, but other pictures look better. I tried some other real censored pictures and got mixed results there too. 
If you want to see some comparisons I'd have to ask you to tell me where I can reach you, since I can't really upload them here. 
I also have a branch with just the faster region finding if grouping doesn't suit this.

Here's a picture of what the grouping does. Feel free to try it yourself if you want, I added the new changes in \_\_main\_\_ in utils.py, but you might have to uncomment the grouping part.
![grouping](https://user-images.githubusercontent.com/17248414/59614409-ffe9bc80-9120-11e9-9580-1d7d2010ff97.png)

Also it seems like my editor made a lot of minor changes such as spaces before comments... sorry.
After writing all of this I realized maybe I should post an issue first asking about this, but screw it.

Thanks.